### PR TITLE
Added get commits by path method

### DIFF
--- a/src/main/java/org/gitlab4j/api/CommitsApi.java
+++ b/src/main/java/org/gitlab4j/api/CommitsApi.java
@@ -88,6 +88,26 @@ public class CommitsApi extends AbstractApi {
     }
 
     /**
+     * Get a list of file commits in a project
+     *
+     * GET /projects/:id/repository/commits?path=:file_path
+     *
+     * @param projectId the project ID to get the list of commits for
+     * @param ref the name of a repository branch or tag or if not given the default branch
+     * @param path the path to file of a project
+     * @return a list containing the commits for the specified project ID and file
+     * @throws GitLabApiException GitLabApiException if any exception occurs during execution
+     */
+    public List<Commit> getCommits(int projectId, String ref, String path) throws GitLabApiException {
+        Form formData = new GitLabApiForm()
+                .withParam("ref_name", ref)
+                .withParam(PER_PAGE_PARAM, getDefaultPerPage());
+        String pathArg = (path == null || path.isEmpty()) ? "commits" : "commits" + "?path=" + path;
+        Response response = get(Response.Status.OK, formData.asMap(), "projects", projectId, "repository", pathArg);
+        return (response.readEntity(new GenericType<List<Commit>>() {}));
+    }
+
+    /**
      * Get a list of repository commits in a project.
      *
      * GET /projects/:id/repository/commits

--- a/src/test/java/org/gitlab4j/api/TestCommitsApi.java
+++ b/src/test/java/org/gitlab4j/api/TestCommitsApi.java
@@ -147,4 +147,15 @@ public class TestCommitsApi {
         assertNotNull(pager);
         assertTrue(pager.getTotalItems() > 0);
     }
+
+    @Test
+    public void testCommitsByPath() throws GitLabApiException {
+        Project project = gitLabApi.getProjectApi().getProject(TEST_NAMESPACE, TEST_PROJECT_NAME);
+
+        CommitsApi commitsApi = gitLabApi.getCommitsApi();
+        List<Commit> commits = commitsApi.getCommits(project.getId(), "master",
+            "edmunds/content/bmw/history.atom");
+        assertNotNull(commits);
+        assertTrue(commits.size() > 0);
+    }
 }


### PR DESCRIPTION
Checkout this issue:
https://github.com/gmessner/gitlab4j-api/issues/71