### PR TITLE
Allow to setup client properties

### DIFF
--- a/src/main/java/org/gitlab4j/api/GitLabApiClient.java
+++ b/src/main/java/org/gitlab4j/api/GitLabApiClient.java
@@ -207,7 +207,9 @@ public class GitLabApiClient {
 
         clientConfig = new ClientConfig();
         if (clientConfigProperties != null) {
-            clientConfig.getProperties().putAll(clientConfigProperties);
+            for (Map.Entry<String, Object> propertyEntry : clientConfigProperties.entrySet()) {
+                clientConfig.property(propertyEntry.getKey(), propertyEntry.getValue());
+            }
         }
 
         clientConfig.register(JacksonJson.class);


### PR DESCRIPTION
`clientConfig.getProperties()` returns immutable view of all properties.
To add properties we need to pass them into `clientConfig.property(name, value)`