### PR TITLE
"ref_name" was changed to "ref" in RepositoryAPI v4

### DIFF
--- a/src/main/java/org/gitlab4j/api/RepositoryApi.java
+++ b/src/main/java/org/gitlab4j/api/RepositoryApi.java
@@ -357,7 +357,7 @@ public class RepositoryApi extends AbstractApi {
         Form formData = new GitLabApiForm()
                 .withParam("id", projectId, true)
                 .withParam("path", filePath, false)
-                .withParam("ref_name", refName, false)
+                .withParam(isApiVersion(ApiVersion.V3) ? "ref_name" : "ref", refName, false)
                 .withParam("recursive", recursive, false)
                 .withParam(PER_PAGE_PARAM, getDefaultPerPage());
         Response response = get(Response.Status.OK, formData.asMap(), "projects", projectId, "repository", "tree");
@@ -386,7 +386,7 @@ public class RepositoryApi extends AbstractApi {
         Form formData = new GitLabApiForm()
                 .withParam("id", projectId, true)
                 .withParam("path", filePath, false)
-                .withParam("ref_name", refName, false)
+                .withParam(isApiVersion(ApiVersion.V3) ? "ref_name" : "ref", refName, false)
                 .withParam("recursive", recursive, false);
         return (new Pager<TreeItem>(this, TreeItem.class, itemsPerPage, formData.asMap(), "projects", projectId, "repository", "tree"));
     }


### PR DESCRIPTION
https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/repositories.md - optional "ref_name" for V3
https://docs.gitlab.com/ce/api/repositories.html - optional "ref" for V4