### PR TITLE
Rework exception handling to attach original exception.

### DIFF
--- a/src/main/java/org/gitlab4j/api/webhook/WebHookManager.java
+++ b/src/main/java/org/gitlab4j/api/webhook/WebHookManager.java
@@ -1,7 +1,6 @@
 
 package org.gitlab4j.api.webhook;
 
-import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -14,9 +13,6 @@ import org.gitlab4j.api.GitLabApiException;
 import org.gitlab4j.api.HookManager;
 import org.gitlab4j.api.utils.HttpRequestUtils;
 import org.gitlab4j.api.utils.JacksonJson;
-
-import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.databind.JsonMappingException;
 
 /**
  * This class provides a handler for processing GitLab WebHook callouts.

--- a/src/main/java/org/gitlab4j/api/webhook/WebHookManager.java
+++ b/src/main/java/org/gitlab4j/api/webhook/WebHookManager.java
@@ -97,11 +97,8 @@ public class WebHookManager extends HookManager {
 
             fireEvent(event);
 
-        } catch (IOException e) {
-            LOG.warning("Error parsing JSON data, error=" + e.getMessage());
-            throw new GitLabApiException(e);
         } catch (Exception e) {
-            LOG.warning("Unexpected error reading JSON data, error=" + e.getMessage());
+            LOG.warning("Error parsing JSON data, exception=" + e.getClass().getSimpleName() + ", error=" + e.getMessage());
             throw new GitLabApiException(e);
         }
     }

--- a/src/main/java/org/gitlab4j/api/webhook/WebHookManager.java
+++ b/src/main/java/org/gitlab4j/api/webhook/WebHookManager.java
@@ -81,7 +81,6 @@ public class WebHookManager extends HookManager {
             throw new GitLabApiException(message);
         }
 
-        String errorMessage = null;
         try {
 
             Event event;
@@ -98,22 +97,13 @@ public class WebHookManager extends HookManager {
 
             fireEvent(event);
 
-        } catch (JsonParseException jpe) {
-            errorMessage = jpe.getMessage();
-            LOG.warning("Error parsing JSON data, error=" + errorMessage);
-        } catch (JsonMappingException jme) {
-            errorMessage = jme.getMessage();
-            LOG.warning("Error mapping JSON data, error=" + errorMessage);
-        } catch (IOException ioe) {
-            errorMessage = ioe.getMessage();
-            LOG.warning("Error reading JSON data, error=" + errorMessage);
+        } catch (IOException e) {
+            LOG.warning("Error parsing JSON data, error=" + e.getMessage());
+            throw new GitLabApiException(e);
         } catch (Exception e) {
-            errorMessage = e.getMessage();
-            LOG.warning("Unexpected error reading JSON data, error=" + errorMessage);
+            LOG.warning("Unexpected error reading JSON data, error=" + e.getMessage());
+            throw new GitLabApiException(e);
         }
-
-        if (errorMessage != null)
-            throw new GitLabApiException(errorMessage);
     }
 
     /**


### PR DESCRIPTION
When an errors occurs in the JSON parsing of the WebHookManager then the exceptions is caught, but completely new exceptions are throws, throwing away any useful information about the original cause.  By creating the `GitlabApiException` with the original exception allows you to use `ex.getCause()` to get to the original data without changing which exceptions are throws from the method.