### PR TITLE
Support New "Job Hook" Hook Renaming

### DIFF
--- a/src/main/java/org/gitlab4j/api/webhook/BuildEvent.java
+++ b/src/main/java/org/gitlab4j/api/webhook/BuildEvent.java
@@ -10,8 +10,10 @@ import org.gitlab4j.api.models.User;
 @XmlAccessorType(XmlAccessType.FIELD)
 public class BuildEvent implements Event {
 
-    public static final String X_GITLAB_EVENT = "Build Hook";
-    public static final String X_GITLAB_EVENT_2 = "Job Hook";
+    /** X-Gitlab-Event header value pre GitLab v9.3.0 */
+    public static final String BUILD_HOOK_X_GITLAB_EVENT = "Build Hook";
+    /** X-Gitlab-Event header value post GitLab v9.3.0 */
+    public static final String JOB_HOOK_X_GITLAB_EVENT = "Job Hook";
     public static final String OBJECT_KIND = "build";
 
     private String ref;

--- a/src/main/java/org/gitlab4j/api/webhook/BuildEvent.java
+++ b/src/main/java/org/gitlab4j/api/webhook/BuildEvent.java
@@ -11,6 +11,7 @@ import org.gitlab4j.api.models.User;
 public class BuildEvent implements Event {
 
     public static final String X_GITLAB_EVENT = "Build Hook";
+    public static final String X_GITLAB_EVENT_2 = "Job Hook";
     public static final String OBJECT_KIND = "build";
 
     private String ref;

--- a/src/main/java/org/gitlab4j/api/webhook/WebHookManager.java
+++ b/src/main/java/org/gitlab4j/api/webhook/WebHookManager.java
@@ -62,6 +62,7 @@ public class WebHookManager extends HookManager {
         switch (eventName) {
 
         case BuildEvent.X_GITLAB_EVENT:
+        case BuildEvent.X_GITLAB_EVENT_2:
         case IssueEvent.X_GITLAB_EVENT:
         case MergeRequestEvent.X_GITLAB_EVENT:
         case NoteEvent.X_GITLAB_EVENT:

--- a/src/main/java/org/gitlab4j/api/webhook/WebHookManager.java
+++ b/src/main/java/org/gitlab4j/api/webhook/WebHookManager.java
@@ -61,8 +61,8 @@ public class WebHookManager extends HookManager {
         LOG.info("handleEvent: X-Gitlab-Event=" + eventName);
         switch (eventName) {
 
-        case BuildEvent.X_GITLAB_EVENT:
-        case BuildEvent.X_GITLAB_EVENT_2:
+        case BuildEvent.BUILD_HOOK_X_GITLAB_EVENT:
+        case BuildEvent.JOB_HOOK_X_GITLAB_EVENT:
         case IssueEvent.X_GITLAB_EVENT:
         case MergeRequestEvent.X_GITLAB_EVENT:
         case NoteEvent.X_GITLAB_EVENT:


### PR DESCRIPTION
closes #130 

Validated by sending a test event from GitLab and it works.