### PR TITLE
Adds missing "MANUAL" job status

### DIFF
--- a/src/main/java/org/gitlab4j/api/models/JobStatus.java
+++ b/src/main/java/org/gitlab4j/api/models/JobStatus.java
@@ -33,7 +33,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
  */
 public enum JobStatus {
 
-    RUNNING, PENDING, SUCCESS, FAILED, CANCELED, SKIPPED;
+    RUNNING, PENDING, SUCCESS, FAILED, CANCELED, SKIPPED, MANUAL;
 
     private static JacksonJsonEnumHelper<JobStatus> enumHelper = new JacksonJsonEnumHelper<>(JobStatus.class);
 


### PR DESCRIPTION
I noticed that the MANUAL status is not present in the JobStatus Enum. A Job will have that status, when it's waiting for a manual trigger (`when: manual` in the .gitlab-ci.yml). 


### Current Situation
As it is currently, when trying to fetch all jobs for a pipeline, such as: 

```bash
 curl  --header "PRIVATE-TOKEN: $SECRET" "https://$HOST/api/v4/projects/$PROJECT/pipelines/$PIPELINE/jobs" 
```

or 

```java
gitLabApi.getJobApi().getJobsForPipeline(projectId, pipelineId)
```

jobs that are waiting to be triggered manually will have a `null` status. Adding this enum value fixes this issue. 