### PR TITLE
Fixed Double-Checked Locking by declaring fields to be volatile

### DIFF
--- a/src/main/java/org/gitlab4j/api/GitLabApi.java
+++ b/src/main/java/org/gitlab4j/api/GitLabApi.java
@@ -42,25 +42,25 @@ public class GitLabApi {
     private int defaultPerPage = DEFAULT_PER_PAGE;
     private Session session;
 
-    private CommitsApi commitsApi;
-    private DeployKeysApi deployKeysApi;
-    private GroupApi groupApi;
-    private IssuesApi issuesApi;
-    private MergeRequestApi mergeRequestApi;
-    private MilestonesApi milestonesApi;
-    private NamespaceApi namespaceApi;
-    private PipelineApi pipelineApi;
-    private ProjectApi projectApi;
-    private RepositoryApi repositoryApi;
-    private RepositoryFileApi repositoryFileApi;
-    private ServicesApi servicesApi;
-    private SessionApi sessionApi;
-    private SystemHooksApi systemHooksApi;
-    private UserApi userApi;
-    private JobApi jobApi;
-    private LabelsApi labelsApi;
-    private NotesApi notesApi;
-    private EventsApi eventsApi;
+    private volatile CommitsApi commitsApi;
+    private volatile DeployKeysApi deployKeysApi;
+    private volatile GroupApi groupApi;
+    private volatile IssuesApi issuesApi;
+    private volatile MergeRequestApi mergeRequestApi;
+    private volatile MilestonesApi milestonesApi;
+    private volatile NamespaceApi namespaceApi;
+    private volatile PipelineApi pipelineApi;
+    private volatile ProjectApi projectApi;
+    private volatile RepositoryApi repositoryApi;
+    private volatile RepositoryFileApi repositoryFileApi;
+    private volatile ServicesApi servicesApi;
+    private volatile SessionApi sessionApi;
+    private volatile SystemHooksApi systemHooksApi;
+    private volatile UserApi userApi;
+    private volatile JobApi jobApi;
+    private volatile LabelsApi labelsApi;
+    private volatile NotesApi notesApi;
+    private volatile EventsApi eventsApi;
 
     /**
      * Create a new GitLabApi instance that is logically a duplicate of this instance, with the exception off sudo state.

--- a/src/main/java/org/gitlab4j/api/GitLabApi.java
+++ b/src/main/java/org/gitlab4j/api/GitLabApi.java
@@ -521,7 +521,7 @@ public class GitLabApi {
 
         // Get the User specified by the sudoAsId, if you are not an admin or the username is not found, this will fail
         User user = getUserApi().getUser(sudoAsId);
-        if (user == null || user.getId() != sudoAsId) {
+        if (user == null || !user.getId().equals(sudoAsId)) {
             throw new GitLabApiException("the specified user ID was not found");
         }
 

--- a/src/main/java/org/gitlab4j/api/RepositoryFileApi.java
+++ b/src/main/java/org/gitlab4j/api/RepositoryFileApi.java
@@ -121,7 +121,7 @@ public class RepositoryFileApi extends AbstractApi {
         if (isApiVersion(ApiVersion.V3)) {
             response = put(Response.Status.OK, formData.asMap(), "projects", projectId, "repository", "files");
         } else {
-            response = put(Response.Status.CREATED, formData.asMap(), "projects", projectId, "repository", "files", urlEncode(file.getFilePath()));
+            response = put(Response.Status.OK, formData.asMap(), "projects", projectId, "repository", "files", urlEncode(file.getFilePath()));
         }
    
         return (response.readEntity(RepositoryFile.class));


### PR DESCRIPTION
Double-Checked Locking without volatile field can work incorrectly
http://www.cs.umd.edu/~pugh/java/memoryModel/DoubleCheckedLocking.html