### PR TITLE
 Implemented being able to set a tag_list when creating and updating a project.

### DIFF
--- a/src/main/java/org/gitlab4j/api/ProjectApi.java
+++ b/src/main/java/org/gitlab4j/api/ProjectApi.java
@@ -646,10 +646,20 @@ public class ProjectApi extends AbstractApi implements Constants {
         if (isApiVersion(ApiVersion.V3)) {
             boolean isPublic = (project.getPublic() != null ? project.getPublic() : project.getVisibility() == Visibility.PUBLIC);
             formData.withParam("public", isPublic);
+            
+            if (project.getTagList() != null && !project.getTagList().isEmpty()) {
+                // What would be the preferred way to deal with this, as the V3 API doesn't
+                // appear to do anything if you send in the tag_list? Could either just ignore,
+                // or throw an exception.
+            }
         } else {
             Visibility visibility = (project.getVisibility() != null ? project.getVisibility() :
                 project.getPublic() == Boolean.TRUE ? Visibility.PUBLIC : null);
             formData.withParam("visibility", visibility);
+            
+            if (project.getTagList() != null && !project.getTagList().isEmpty()) {
+                formData.withParam("tag_list", String.join(",", project.getTagList()));
+            }
         }
 
         if (project.getNamespace() != null) {
@@ -877,10 +887,20 @@ public class ProjectApi extends AbstractApi implements Constants {
             formData.withParam("visibility_level", project.getVisibilityLevel());
             boolean isPublic = (project.getPublic() != null ? project.getPublic() : project.getVisibility() == Visibility.PUBLIC);
             formData.withParam("public", isPublic);
+            
+            if (project.getTagList() != null && !project.getTagList().isEmpty()) {
+                // What would be the preferred way to deal with this, as the V3 API doesn't
+                // appear to do anything if you send in the tag_list? Could either just ignore,
+                // or throw an exception.
+            }
         } else {
             Visibility visibility = (project.getVisibility() != null ? project.getVisibility() :
                 project.getPublic() == Boolean.TRUE ? Visibility.PUBLIC : null);
             formData.withParam("visibility", visibility);
+            
+            if (project.getTagList() != null && !project.getTagList().isEmpty()) {
+                formData.withParam("tag_list", String.join(",", project.getTagList()));
+            }
         }
 
         Response response = putWithFormData(Response.Status.OK, formData, "projects", id);

--- a/src/test/java/org/gitlab4j/api/TestProjectApi.java
+++ b/src/test/java/org/gitlab4j/api/TestProjectApi.java
@@ -29,6 +29,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
@@ -169,7 +170,8 @@ public class TestProjectApi {
                 .withMergeRequestsEnabled(true)
                 .withWikiEnabled(true)
                 .withSnippetsEnabled(true)
-                .withVisibility(Visibility.PUBLIC);
+                .withVisibility(Visibility.PUBLIC)
+                .withTagList(Arrays.asList("tag1","tag2"));
 
         Project newProject = gitLabApi.getProjectApi().createProject(project);
         assertNotNull(newProject);
@@ -179,6 +181,7 @@ public class TestProjectApi {
         assertEquals(project.getMergeRequestsEnabled(), newProject.getMergeRequestsEnabled());
         assertEquals(project.getWikiEnabled(), newProject.getWikiEnabled());
         assertEquals(project.getSnippetsEnabled(), newProject.getSnippetsEnabled());
+        assertEquals(project.getTagList(), newProject.getTagList());
         assertTrue(Visibility.PUBLIC == newProject.getVisibility() || Boolean.TRUE == newProject.getPublic());
     }
 
@@ -192,7 +195,8 @@ public class TestProjectApi {
                 .withMergeRequestsEnabled(true)
                 .withWikiEnabled(true)
                 .withSnippetsEnabled(true)
-                .withVisibility(Visibility.PUBLIC);
+                .withVisibility(Visibility.PUBLIC)
+                .withTagList(Arrays.asList("tag1","tag2"));
 
         Project newProject = gitLabApi.getProjectApi().createProject(project);
         assertNotNull(newProject);
@@ -202,6 +206,7 @@ public class TestProjectApi {
         assertEquals(project.getMergeRequestsEnabled(), newProject.getMergeRequestsEnabled());
         assertEquals(project.getWikiEnabled(), newProject.getWikiEnabled());
         assertEquals(project.getSnippetsEnabled(), newProject.getSnippetsEnabled());
+        assertEquals(project.getTagList(), newProject.getTagList());
         assertTrue(Visibility.PUBLIC == newProject.getVisibility() || Boolean.TRUE == newProject.getPublic());
 
         project = new Project()


### PR DESCRIPTION
I've left a note in for the V3 API section as I wasn't sure if you'd prefer to just ignore tag lists here (Gitlab doesn't appear to do anything with them if you send them) or throw some sort of exception.

I've added what I think the unit test changes should be, but couldn't work out what needed setting up to run them.