### PR TITLE
using post method instead of get to enable a runner

### DIFF
--- a/src/main/java/org/gitlab4j/api/RunnersApi.java
+++ b/src/main/java/org/gitlab4j/api/RunnersApi.java
@@ -324,7 +324,7 @@ public class RunnersApi extends AbstractApi {
         }
         GitLabApiForm formData = new GitLabApiForm()
                 .withParam("runner_id", runnerId, true);
-        Response response = get(Response.Status.OK, formData.asMap(), "projects", projectId, "runners");
+        Response response = post(Response.Status.CREATED, formData.asMap(), "projects", projectId, "runners");
         return (response.readEntity(Runner.class));
     }
 


### PR DESCRIPTION
Hi,

This fix changes the enableRunner() method of RunnersApi to use the http POST method instead of GET to perform the operation.

Best regards,
Fouad