### PR TITLE
Get more information from gitlab

### DIFF
--- a/src/main/java/org/gitlab4j/api/AbstractApi.java
+++ b/src/main/java/org/gitlab4j/api/AbstractApi.java
@@ -3,7 +3,6 @@ package org.gitlab4j.api;
 import java.io.File;
 import java.net.URL;
 import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 
 import javax.ws.rs.NotAuthorizedException;
 import javax.ws.rs.core.Form;

--- a/src/main/java/org/gitlab4j/api/AbstractApi.java
+++ b/src/main/java/org/gitlab4j/api/AbstractApi.java
@@ -3,6 +3,7 @@ package org.gitlab4j.api;
 import java.io.File;
 import java.net.URL;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 import javax.ws.rs.NotAuthorizedException;
 import javax.ws.rs.core.Form;
@@ -80,6 +81,31 @@ public abstract class AbstractApi implements Constants {
     protected String urlEncode(String s) throws GitLabApiException {
         try {
             String encoded = URLEncoder.encode(s, "UTF-8");
+            encoded = encoded.replace(".", "%2E");
+            encoded = encoded.replace("-", "%2D");
+            encoded = encoded.replace("_", "%5F");
+            return (encoded);
+        } catch (Exception e) {
+            throw new GitLabApiException(e);
+        }
+    }
+    
+    /**
+     * Encode a string to be used as in-path argument for a gitlab api request.
+     * 
+     * Standard URL encoding changes spaces to plus signs, but for arguments that are part of the path,
+     * like the :file_path in a "Get raw file" request, gitlab expects spaces to be encoded with %20.
+     * 
+     * @param s the string to encode
+     * @return encoded version of s with spaces encoded as %2F
+     * @throws GitLabApiException if encoding throws an exception
+     */
+    protected String urlEncodeForPath(String s) throws GitLabApiException {
+        try {
+            String encoded = URLEncoder.encode(s, "UTF-8");
+            // Since the encode method encodes plus signs as %2B,
+            // we can simply replace the encoded spaces with the correct encoding here 
+            encoded = encoded.replace("+", "%20");
             encoded = encoded.replace(".", "%2E");
             encoded = encoded.replace("-", "%2D");
             encoded = encoded.replace("_", "%5F");

--- a/src/main/java/org/gitlab4j/api/CommitsApi.java
+++ b/src/main/java/org/gitlab4j/api/CommitsApi.java
@@ -302,6 +302,21 @@ public class CommitsApi extends AbstractApi {
         Response response = get(Response.Status.OK, null, "projects", projectId, "repository", "commits", sha, "comments");
         return (response.readEntity(new GenericType<List<Comment>>() {}));
     }
+    
+    /**
+     * Get a Pager of the comments of a commit in a project.
+     *
+     * GET /projects/:id/repository/commits/:sha/comments
+     *
+     * @param projectId the project ID that the commit belongs to
+     * @param sha a commit hash or name of a branch or tag
+     * @param itemsPerPage the number of Comment instances that will be fetched per page
+     * @return a List of Comment instances for the specified project ID/sha pair
+     * @throws GitLabApiException GitLabApiException if any exception occurs during execution
+     */
+    public Pager<Comment> getComments(int projectId, String sha, int itemsPerPage) throws GitLabApiException {
+        return new Pager<Comment>(this, Comment.class, itemsPerPage, null, "projects", projectId, "repository", "commits", sha, "comments");
+    }
 
     /**
      * Add a comment to a commit.  In order to post a comment in a particular line of a particular file,

--- a/src/main/java/org/gitlab4j/api/GitLabApi.java
+++ b/src/main/java/org/gitlab4j/api/GitLabApi.java
@@ -37,7 +37,7 @@ public class GitLabApi {
         }
     }
 
-    // Used to keep track of GitLabApiExceptions on calls that return Optionsl<?>
+    // Used to keep track of GitLabApiExceptions on calls that return Optional<?>
     private static final Map<Optional<?>, GitLabApiException> optionalExceptionMap =
             Collections.synchronizedMap(new WeakHashMap<Optional<?>, GitLabApiException>());
 

--- a/src/main/java/org/gitlab4j/api/MergeRequestApi.java
+++ b/src/main/java/org/gitlab4j/api/MergeRequestApi.java
@@ -577,4 +577,20 @@ public class MergeRequestApi extends AbstractApi {
         Response response = post(Response.Status.OK, (Form)null, "projects", projectId, "merge_requests", mergeRequestIid, "unapprove");
         return (response.readEntity(MergeRequest.class));
     }
+
+    /**
+     * Get merge request with changes information.
+     *
+     * GET /projects/:id/merge_requests/:merge_request_iid/changes
+     *
+     * @param projectId the project ID to get the merge requests for
+     * @param mergeRequestIid the IID of the merge request to get
+     * @param itemsPerPage the number of MergeRequest instances that will be fetched per page
+     * @return all merge requests for the specified project
+     * @throws GitLabApiException if any exception occurs
+     */
+    public MergeRequest getMergeRequestChanges(Integer projectId, Integer mergeRequestIid, int itemsPerPage) throws GitLabApiException {
+        Response response = get(Response.Status.OK, null, "projects", projectId, "merge_requests", mergeRequestIid, "changes");
+        return (response.readEntity(MergeRequest.class));
+    }
 }

--- a/src/main/java/org/gitlab4j/api/MergeRequestApi.java
+++ b/src/main/java/org/gitlab4j/api/MergeRequestApi.java
@@ -10,6 +10,7 @@ import javax.ws.rs.core.Response;
 import org.gitlab4j.api.GitLabApi.ApiVersion;
 import org.gitlab4j.api.models.Commit;
 import org.gitlab4j.api.models.MergeRequest;
+import org.gitlab4j.api.models.Participant;
 
 /**
  * This class implements the client side API for the GitLab merge request calls.
@@ -585,12 +586,26 @@ public class MergeRequestApi extends AbstractApi {
      *
      * @param projectId the project ID to get the merge requests for
      * @param mergeRequestIid the IID of the merge request to get
-     * @param itemsPerPage the number of MergeRequest instances that will be fetched per page
-     * @return all merge requests for the specified project
+     * @return a merge request including its changes
      * @throws GitLabApiException if any exception occurs
      */
-    public MergeRequest getMergeRequestChanges(Integer projectId, Integer mergeRequestIid, int itemsPerPage) throws GitLabApiException {
+    public MergeRequest getMergeRequestChanges(Integer projectId, Integer mergeRequestIid) throws GitLabApiException {
         Response response = get(Response.Status.OK, null, "projects", projectId, "merge_requests", mergeRequestIid, "changes");
         return (response.readEntity(MergeRequest.class));
+    }
+    
+    /**
+     * Get participants of merge request.
+     * 
+     * GET /projects/:id/merge_requests/:merge_request_iid/participants
+     * 
+     * @param projectId the project ID to get the merge requests for
+     * @param mergeRequestIid the IID of the merge request to get
+     * @param itemsPerPage the number of Participant instances that will be fetched per page
+     * @return all participants for the specified merge request
+     * @throws GitLabApiException if any exception occurs
+     */
+    public Pager<Participant> getParticipants(Integer projectId, Integer mergeRequestIid, int itemsPerPage) throws GitLabApiException {
+        return new Pager<Participant>(this, Participant.class, itemsPerPage, null, "projects", projectId, "merge_requests", mergeRequestIid, "participants");
     }
 }

--- a/src/main/java/org/gitlab4j/api/ProjectApi.java
+++ b/src/main/java/org/gitlab4j/api/ProjectApi.java
@@ -2054,4 +2054,18 @@ public class ProjectApi extends AbstractApi implements Constants {
 
         delete(Response.Status.OK, null, "projects", projectId, "push_rule");
     }
+    
+    /**
+     * Get a Pager of projects that were forked from the specified project.
+     * 
+     * GET /projects/:id/forks
+     * 
+     * @param projectId the ID of the project
+     * @param itemsPerPage the number of Project instances that will be fetched per page
+     * @return a Pager of projects
+     * @throws GitLabApiException if any exception occurs
+     */
+    public Pager<Project> getForks(Integer projectId, int itemsPerPage) throws GitLabApiException {
+        return new Pager<Project>(this, Project.class, itemsPerPage, null, "projects", projectId, "forks");
+    }
 }

--- a/src/main/java/org/gitlab4j/api/ProjectApi.java
+++ b/src/main/java/org/gitlab4j/api/ProjectApi.java
@@ -1811,7 +1811,7 @@ public class ProjectApi extends AbstractApi implements Constants {
         delete(Response.Status.NO_CONTENT, null, "projects", projectId, "snippets", snippetId);
     }
 
-    /*
+    /**
      * Get the raw project snippet as plain text.
      *
      * GET /projects/:id/snippets/:snippet_id/raw
@@ -1826,7 +1826,7 @@ public class ProjectApi extends AbstractApi implements Constants {
         return (response.readEntity(String.class));
     }
 
-    /*
+    /**
      * Get the raw project snippet plain text as an Optional instance.
      *
      * GET /projects/:id/snippets/:snippet_id/raw

--- a/src/main/java/org/gitlab4j/api/RepositoryApi.java
+++ b/src/main/java/org/gitlab4j/api/RepositoryApi.java
@@ -17,6 +17,7 @@ import javax.ws.rs.core.Response;
 import org.gitlab4j.api.GitLabApi.ApiVersion;
 import org.gitlab4j.api.models.Branch;
 import org.gitlab4j.api.models.CompareResults;
+import org.gitlab4j.api.models.Contributor;
 import org.gitlab4j.api.models.Tag;
 import org.gitlab4j.api.models.TreeItem;
 import org.gitlab4j.api.utils.FileUtils;
@@ -497,5 +498,20 @@ public class RepositoryApi extends AbstractApi {
 
         Response response = get(Response.Status.OK, formData.asMap(), "projects", projectPath, "repository", "compare");
         return (response.readEntity(CompareResults.class));
+    }
+    
+    /**
+     * Get a Pager of contributors from a project.
+     *
+     * GET /projects/:id/repository/contributors
+     *
+     * @param projectId the project to get the list of contributors for
+     * @param itemsPerPage the number of Project instances that will be fetched per page
+     * @return the list of contributors for the specified project ID
+     *
+     * @throws GitLabApiException if any exception occurs
+     */
+    public Pager<Contributor> getContributors(Integer projectId, int itemsPerPage) throws GitLabApiException {
+        return new Pager<Contributor>(this, Contributor.class, itemsPerPage, null, "projects", projectId, "repository", "contributors");
     }
 }

--- a/src/main/java/org/gitlab4j/api/RepositoryFileApi.java
+++ b/src/main/java/org/gitlab4j/api/RepositoryFileApi.java
@@ -43,7 +43,7 @@ public class RepositoryFileApi extends AbstractApi {
         Form form = new Form();
         addFormParam(form, "ref", ref, true);
         Response response = get(Response.Status.OK, form.asMap(),
-                "projects", projectId, "repository", "files", urlEncode(filePath));
+                "projects", projectId, "repository", "files", urlEncodeForPath(filePath));
         return (response.readEntity(RepositoryFile.class));
     }
 

--- a/src/main/java/org/gitlab4j/api/models/Contributor.java
+++ b/src/main/java/org/gitlab4j/api/models/Contributor.java
@@ -1,0 +1,7 @@
+package org.gitlab4j.api.models;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement
+public class Contributor extends AbstractUser {
+}

--- a/src/main/java/org/gitlab4j/api/models/MergeRequest.java
+++ b/src/main/java/org/gitlab4j/api/models/MergeRequest.java
@@ -19,7 +19,7 @@ public class MergeRequest {
     private Integer approvalsBeforeMerge;
     private Assignee assignee;
     private Author author;
-    private Diff changes;
+    private List<Diff> changes;
     private Date createdAt;
     private String description;
     private Integer downvotes;
@@ -80,11 +80,11 @@ public class MergeRequest {
         this.author = author;
     }
 
-    public Diff getChanges() {
+    public List<Diff> getChanges() {
         return changes;
     }
 
-    public void setChanges(Diff changes) {
+    public void setChanges(List<Diff> changes) {
         this.changes = changes;
     }
 

--- a/src/main/java/org/gitlab4j/api/models/Participant.java
+++ b/src/main/java/org/gitlab4j/api/models/Participant.java
@@ -1,0 +1,7 @@
+package org.gitlab4j.api.models;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement
+public class Participant extends AbstractUser {
+}


### PR DESCRIPTION
Hey,

as mentioned in issue #180 before, here is a pull request with additions to the API. I added more than just the one missing method in this. I hope it's fine to merge it alltogether.

Additions:
+ get commit comments
+ get merge request changes: basically a diff of the merge request
+ get merge request participants
+ get project forks
+ get repository contributors

Fixes:
+ getFile method encoded spaces in file paths as + and not %F0, as gitlab wants.