### PR TITLE
Adds a new updateMergeRequest method with more attributes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,8 @@
 		<jackson.version>2.9.3</jackson.version>
 		<javaServlet.version>3.1.0</javaServlet.version>
 		<junit.version>4.12</junit.version>
+		<mockito.version>1.10.19</mockito.version>
+		<hamcrest.version>1.3</hamcrest.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 	</properties>
@@ -242,6 +244,18 @@
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<version>${junit.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-all</artifactId>
+			<version>${mockito.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.hamcrest</groupId>
+			<artifactId>hamcrest-all</artifactId>
+			<version>${hamcrest.version}</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/src/main/java/org/gitlab4j/api/MergeRequestApi.java
+++ b/src/main/java/org/gitlab4j/api/MergeRequestApi.java
@@ -329,20 +329,60 @@ public class MergeRequestApi extends AbstractApi {
      * @param stateEvent new state for the merge request, optional
      * @param labels comma separated list of labels, optional
      * @param milestoneId the ID of a milestone, optional
+     * @param removeSourceBranch Flag indicating if a merge request should remove the source
+     *                           branch when merging, optional
+     * @param squash Squash commits into a single commit when merging, optional
+     * @param discussionLocked Flag indicating if the merge request's discussion is locked, optional
+     * @param allowCollaboration Allow commits from members who can merge to the target branch,
+     *                           optional
      * @return the updated merge request
      * @throws GitLabApiException if any exception occurs
      */
+    public MergeRequest updateMergeRequest(Integer projectId, Integer mergeRequestIid,
+            String targetBranch, String title, Integer assigneeId, String description,
+            StateEvent stateEvent, String labels, Integer milestoneId, Boolean removeSourceBranch,
+            Boolean squash, Boolean discussionLocked, Boolean allowCollaboration)
+            throws GitLabApiException {
+
+        Form formData = new GitLabApiForm()
+                .withParam("target_branch", targetBranch)
+                .withParam("title", title)
+                .withParam("assignee_id", assigneeId)
+                .withParam("description", description)
+                .withParam("state_event", stateEvent)
+                .withParam("labels", labels)
+                .withParam("milestone_id", milestoneId)
+                .withParam("remove_source_branch", removeSourceBranch)
+                .withParam("squash", squash)
+                .withParam("discussion_locked", discussionLocked)
+                .withParam("allow_collaboration", allowCollaboration);
+
+        return updateMergeRequest(projectId, mergeRequestIid, formData);
+    }
+
+    /**
+     * Updates an existing merge request. You can change branches, title, or even close the MR.
+     *
+     * <p>NOTE: GitLab API V4 uses IID (internal ID), V3 uses ID to identify the merge request.</p>
+     *
+     * PUT /projects/:id/merge_requests/:merge_request_iid
+     *
+     * @param projectId the ID of a project
+     * @param mergeRequestIid the internal ID of the merge request to update
+     * @param targetBranch the target branch, optional
+     * @param title the title for the merge request
+     * @param assigneeId the Assignee user ID, optional
+     * @param description the description of the merge request, optional
+     * @param stateEvent new state for the merge request, optional
+     * @param labels comma separated list of labels, optional
+     * @param milestoneId the ID of a milestone, optional
+     * @return the updated merge request
+     * @throws GitLabApiException if any exception occurs
+     */
+    @Deprecated
     public MergeRequest updateMergeRequest(Integer projectId, Integer mergeRequestIid, String targetBranch,
             String title, Integer assigneeId, String description, StateEvent stateEvent, String labels,
             Integer milestoneId) throws GitLabApiException {
-
-        if (projectId == null) {
-            throw new RuntimeException("projectId cannot be null");
-        }
-
-        if (mergeRequestIid == null) {
-            throw new RuntimeException("mergeRequestIid cannot be null");
-        }
 
         Form formData = new GitLabApiForm()
         .withParam("target_branch", targetBranch)
@@ -353,8 +393,7 @@ public class MergeRequestApi extends AbstractApi {
         .withParam("labels", labels)
         .withParam("milestone_id", milestoneId);
 
-        Response response = put(Response.Status.OK, formData.asMap(), "projects", projectId, "merge_requests", mergeRequestIid);
-        return (response.readEntity(MergeRequest.class));
+        return updateMergeRequest(projectId, mergeRequestIid, formData);
     }
 
     /**
@@ -379,6 +418,19 @@ public class MergeRequestApi extends AbstractApi {
     public MergeRequest updateMergeRequest(Integer projectId, Integer mergeRequestIid, String sourceBranch, String targetBranch, String title, String description,
             Integer assigneeId) throws GitLabApiException {
 
+        Form formData = new Form();
+        addFormParam(formData, "source_branch", sourceBranch, false);
+        addFormParam(formData, "target_branch", targetBranch, false);
+        addFormParam(formData, "title", title, false);
+        addFormParam(formData, "description", description, false);
+        addFormParam(formData, "assignee_id", assigneeId, false);
+
+        return updateMergeRequest(projectId, mergeRequestIid, formData);
+    }
+
+    protected MergeRequest updateMergeRequest(Integer projectId, Integer mergeRequestIid,
+            Form formData) throws GitLabApiException {
+
         if (projectId == null) {
             throw new RuntimeException("projectId cannot be null");
         }
@@ -387,14 +439,8 @@ public class MergeRequestApi extends AbstractApi {
             throw new RuntimeException("mergeRequestId cannot be null");
         }
 
-        Form formData = new Form();
-        addFormParam(formData, "source_branch", sourceBranch, false);
-        addFormParam(formData, "target_branch", targetBranch, false);
-        addFormParam(formData, "title", title, false);
-        addFormParam(formData, "description", description, false);
-        addFormParam(formData, "assignee_id", assigneeId, false);
-
-        Response response = put(Response.Status.OK, formData.asMap(), "projects", projectId, "merge_requests", mergeRequestIid);
+        Response response = put(Response.Status.OK, formData.asMap(), "projects", projectId,
+                "merge_requests", mergeRequestIid);
         return (response.readEntity(MergeRequest.class));
     }
 

--- a/src/test/java/org/gitlab4j/api/TestMergeRequestApi.java
+++ b/src/test/java/org/gitlab4j/api/TestMergeRequestApi.java
@@ -1,0 +1,66 @@
+package org.gitlab4j.api;
+
+import org.gitlab4j.api.models.MergeRequest;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+import java.util.Collections;
+
+import static org.hamcrest.Matchers.hasEntry;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class TestMergeRequestApi {
+
+    @Mock private GitLabApi gitLabApi;
+    @Mock private GitLabApiClient gitLabApiClient;
+    @Mock private Response response;
+
+    @Captor private ArgumentCaptor<MultivaluedMap<String, String>> attributeCaptor;
+
+    @Before
+    public void setUp() throws Exception {
+        initMocks(this);
+
+        when(gitLabApi.getApiClient()).thenReturn(gitLabApiClient);
+
+        when(gitLabApiClient.validateSecretToken(any())).thenReturn(true);
+        when(gitLabApiClient.put(attributeCaptor.capture(), Mockito.<Object>anyVararg()))
+                .thenReturn(response);
+
+        when(response.getStatus()).thenReturn(200);
+        when(response.getEntity()).thenReturn(new MergeRequest());
+    }
+
+    @Test
+    public void whenAllArgumentsNull_thenNoAttributesSent() throws Exception {
+        new MergeRequestApi(gitLabApi).updateMergeRequest(1, 2, null, null, null, null, null, null,
+                null, null, null, null, null);
+        assertEquals(0, attributeCaptor.getValue().size());
+    }
+
+    @Test
+    public void falseBooleansAreSerializedCorrectly() throws Exception {
+        new MergeRequestApi(gitLabApi).updateMergeRequest(1, 2, null, null, null, null, null, null,
+                null, null, null, null, false);
+        assertThat(attributeCaptor.getValue(),
+                hasEntry("allow_collaboration", Collections.singletonList("false")));
+    }
+
+    @Test
+    public void trueBooleansAreSerializedCorrectly() throws Exception {
+        new MergeRequestApi(gitLabApi).updateMergeRequest(1, 2, null, null, null, null, null, null,
+                null, null, null, null, true);
+        assertThat(attributeCaptor.getValue(),
+                hasEntry("allow_collaboration", Collections.singletonList("true")));
+    }
+}


### PR DESCRIPTION
I deprecated the existing updateMergeRequest method and added a new updateMergeRequest method which accepts more parameters. These new parameters correspond to the attributes [listed here](https://docs.gitlab.com/ee/api/merge_requests.html#update-mr) that were previously not settable.

Closes #205 

Since there were now 3 different updateMergeRequest methods which contained duplicated code, I abstracted the common logic to a protected method

```java
protected MergeRequest updateMergeRequest(Integer projectId, Integer mergeRequestIid, Form formData)
```
The reason it is protected and not private is so that in the future, users of this library can extend the class to add new attributes themselves, instead of waiting for the library to update. I'm curious if making it a public method would be preferable.