### PR TITLE
add fluent interface implementation to groupModel

### DIFF
--- a/src/main/java/org/gitlab4j/api/models/Group.java
+++ b/src/main/java/org/gitlab4j/api/models/Group.java
@@ -195,4 +195,84 @@ public class Group {
     public void setSharedProjects(List<Project> sharedProjects) {
         this.sharedProjects = sharedProjects;
     }
+
+    public Group withId(Integer id) {
+        this.id = id;
+        return this;
+    }
+
+    public Group withName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public Group withPath(String path) {
+        this.path = path;
+        return this;
+    }
+
+    public Group withDescription(String description) {
+        this.description = description;
+        return this;
+    }
+
+    public Group withVisibility(Visibility visibility) {
+        this.visibility = visibility;
+        return this;
+    }
+
+    public Group withlfsEnabled(boolean lfsEnabled) {
+        this.lfsEnabled = lfsEnabled;
+        return this;
+    }
+
+    public Group withAvatarUrl(String avatarUrl) {
+        this.avatarUrl = avatarUrl;
+        return this;
+    }
+
+    public Group withWebUrl(String url) {
+        this.webUrl = url;
+        return this;
+    }
+
+    public Group withRequestAccessEnabled(boolean requestAccessEnabled) {
+        this.requestAccessEnabled = requestAccessEnabled;
+        return this;
+    }
+
+    public Group withFullName(String fullName) {
+        this.fullName = fullName;
+        return this;
+    }
+
+    public Group withFullPath(String fullPath) {
+        this.fullPath = fullPath;
+        return this;
+    }
+
+    public Group withParentId(Integer parentId) {
+        this.parentId = parentId;
+        return this;
+    }
+
+    public Group withSharedRunnersMinutesLimit(Integer minutesLimit) {
+        this.sharedRunnersMinutesLimit = minutesLimit;
+        return this;
+    }
+
+    public Group withStatistics(Statistics statistics) {
+        this.statistics = statistics;
+        return this;
+    }
+
+    public Group withProjects(List<Project> projects) {
+        this.projects = projects;
+        return this;
+    }
+
+    public Group withSharedProjects(List<Project> sharedProjects) {
+        this.sharedProjects = sharedProjects;
+        return this;
+    }
 }

--- a/src/main/java/org/gitlab4j/api/models/Member.java
+++ b/src/main/java/org/gitlab4j/api/models/Member.java
@@ -65,4 +65,29 @@ public class Member {
     public void setUsername(String username) {
         this.username = username;
     }
+
+    public Member withAccessLevel(AccessLevel accessLevel) {
+        this.accessLevel = accessLevel;
+        return this;
+    }
+
+    public Member withCreatedAt(Date createdAt) {
+        this.createdAt = createdAt;
+        return this;
+    }
+
+    public Member withId(Integer id) {
+        this.id = id;
+        return this;
+    }
+
+    public Member withState(String state) {
+        this.state = state;
+        return this;
+    }
+
+    public Member withUsername(String username) {
+        this.username = username;
+        return this;
+    }
 }

--- a/src/main/java/org/gitlab4j/api/models/Namespace.java
+++ b/src/main/java/org/gitlab4j/api/models/Namespace.java
@@ -53,4 +53,29 @@ public class Namespace {
     public void setFullPath(String fullPath) {
         this.fullPath = fullPath;
     }
+
+    public Namespace withId(Integer id) {
+        this.id = id;
+        return this;
+    }
+
+    public Namespace withName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public Namespace withPath(String path) {
+        this.path = path;
+        return this;
+    }
+
+    public Namespace withKind(String kind) {
+        this.kind = kind;
+        return this;
+    }
+
+    public Namespace withFullPath(String fullPath) {
+        this.fullPath = fullPath;
+        return this;
+    }
 }


### PR DESCRIPTION
Fluent Interfaces are present in project-models, but aren't in group-models and member-models. 
They are cool f.e. for testing purposes.