### PR TITLE
fix: LAST_ACTIVITY => LAST_ACTIVITY_AT

### DIFF
--- a/src/main/java/org/gitlab4j/api/Constants.java
+++ b/src/main/java/org/gitlab4j/api/Constants.java
@@ -86,7 +86,7 @@ public interface Constants {
     /** Enum to use for ordering the results of getProjects(). */
     public enum ProjectOrderBy {
 
-        ID, NAME, PATH, CREATED_AT, UPDATED_AT, LAST_ACTIVITY;
+        ID, NAME, PATH, CREATED_AT, UPDATED_AT, LAST_ACTIVITY_AT;
         private static JacksonJsonEnumHelper<ProjectOrderBy> enumHelper = new JacksonJsonEnumHelper<>(ProjectOrderBy.class);
 
         @JsonCreator


### PR DESCRIPTION
return "bad request" response `{"error":"order_by does not have a valid value"}` in GitLab version `11.1.4 `.   
fix ref: [https://docs.gitlab.com/ee/api/projects.html#list-all-projects](https://docs.gitlab.com/ee/api/projects.html#list-all-projects)