### PR TITLE
Add note on Gradle requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ There have been reports of problems resolving some dependencies when using Ivy o
 <a href="https://github.com/eclipse-ee4j/jaxrs-api/issues/571">JAX-RS API Issue #571</a><br/>
 <a href="https://github.com/eclipse-ee4j/jaxrs-api/issues/572">JAX-RS API Issue #572</a>
 
+**Gradle**<br/>
+Pulling dependencies will fail when using Gradle prior to 4.5. See [Gradle issue 3065](https://github.com/gradle/gradle/issues/3065#issuecomment-364092456)
+
 ---
 
 ## Javadocs

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ dependencies {
 }
 ```
 
+**NOTE:** Pulling dependencies may fail when using Gradle prior to 4.5. See [Gradle issue 3065](https://github.com/gradle/gradle/issues/3065#issuecomment-364092456)
+
 **Maven: pom.xml**
 ```xml
 <dependency>
@@ -28,9 +30,6 @@ dependencies {
 There have been reports of problems resolving some dependencies when using Ivy or SBT, for help resolving those issues see:<br/>
 <a href="https://github.com/eclipse-ee4j/jaxrs-api/issues/571">JAX-RS API Issue #571</a><br/>
 <a href="https://github.com/eclipse-ee4j/jaxrs-api/issues/572">JAX-RS API Issue #572</a>
-
-**Gradle**<br/>
-Pulling dependencies will fail when using Gradle prior to 4.5. See [Gradle issue 3065](https://github.com/gradle/gradle/issues/3065#issuecomment-364092456)
 
 ---
 


### PR DESCRIPTION
Gradle prior to 4.5 can't pull the dependencies when running through a proxy like Nexus.