### PR TITLE
Use correct visibility value in addGroup(Group)

### DIFF
--- a/src/main/java/org/gitlab4j/api/GroupApi.java
+++ b/src/main/java/org/gitlab4j/api/GroupApi.java
@@ -347,7 +347,7 @@ public class GroupApi extends AbstractApi {
                 .withParam("name", group.getName())
                 .withParam("path", group.getPath())
                 .withParam("description", group.getDescription())
-                .withParam("visibility", group.getDescription())
+                .withParam("visibility", group.getVisibility())
                 .withParam("lfs_enabled", group.getLfsEnabled())
                 .withParam("request_access_enabled", group.getRequestAccessEnabled())
                 .withParam("parent_id", isApiVersion(ApiVersion.V3) ? null : group.getParentId());


### PR DESCRIPTION
The implementation `org.gitlab4j.api.GroupApi.addGroup(Group)` has in small bug:

The parameter `visibility` is filled with the value of `group.getDescription()` instead of  `group.getVisibility()`

Hence the request is failing, if description is set. Also it's not possible to change the default visibility `private`.