### PR TITLE
Add support for resolve_outdated_diff_discussions in Project

### DIFF
--- a/src/main/java/org/gitlab4j/api/ProjectApi.java
+++ b/src/main/java/org/gitlab4j/api/ProjectApi.java
@@ -655,6 +655,7 @@ public class ProjectApi extends AbstractApi implements Constants {
      * repositoryStorage (optional) - Which storage shard the repository is on. Available only to admins
      * approvalsBeforeMerge (optional) - How many approvers should approve merge request by default
      * printingMergeRequestLinkEnabled (optional) - Show link to create/view merge request when pushing from the command line
+     * resolveOutdatedDiffDiscussions (optional) - Automatically resolve merge request diffs discussions on lines changed with a push
      *
      * @param project the Project instance with the configuration for the new project
      * @param importUrl the URL to import the repository from
@@ -696,7 +697,8 @@ public class ProjectApi extends AbstractApi implements Constants {
             .withParam("repository_storage", project.getRepositoryStorage())
             .withParam("approvals_before_merge", project.getApprovalsBeforeMerge())
             .withParam("import_url", importUrl)
-            .withParam("printing_merge_request_link_enabled", project.getPrintingMergeRequestLinkEnabled());
+            .withParam("printing_merge_request_link_enabled", project.getPrintingMergeRequestLinkEnabled())
+            .withParam("resolve_outdated_diff_discussions", project.getResolveOutdatedDiffDiscussions());
 
         if (isApiVersion(ApiVersion.V3)) {
             boolean isPublic = (project.getPublic() != null ? project.getPublic() : project.getVisibility() == Visibility.PUBLIC);
@@ -889,6 +891,7 @@ public class ProjectApi extends AbstractApi implements Constants {
      * repositoryStorage (optional) - Which storage shard the repository is on. Available only to admins
      * approvalsBeforeMerge (optional) - How many approvers should approve merge request by default
      * printingMergeRequestLinkEnabled (optional) - Show link to create/view merge request when pushing from the command line
+     * resolveOutdatedDiffDiscussions (optional) - Automatically resolve merge request diffs discussions on lines changed with a push
      *
      * NOTE: The following parameters specified by the GitLab API edit project are not supported:
      *     import_url
@@ -936,7 +939,8 @@ public class ProjectApi extends AbstractApi implements Constants {
             .withParam("request_access_enabled", project.getRequestAccessEnabled())
             .withParam("repository_storage", project.getRepositoryStorage())
             .withParam("approvals_before_merge", project.getApprovalsBeforeMerge())
-            .withParam("printing_merge_request_link_enabled", project.getPrintingMergeRequestLinkEnabled());
+            .withParam("printing_merge_request_link_enabled", project.getPrintingMergeRequestLinkEnabled())
+            .withParam("resolve_outdated_diff_discussions", project.getResolveOutdatedDiffDiscussions());
 
         if (isApiVersion(ApiVersion.V3)) {
             formData.withParam("visibility_level", project.getVisibilityLevel());

--- a/src/main/java/org/gitlab4j/api/ProjectApi.java
+++ b/src/main/java/org/gitlab4j/api/ProjectApi.java
@@ -656,6 +656,7 @@ public class ProjectApi extends AbstractApi implements Constants {
      * approvalsBeforeMerge (optional) - How many approvers should approve merge request by default
      * printingMergeRequestLinkEnabled (optional) - Show link to create/view merge request when pushing from the command line
      * resolveOutdatedDiffDiscussions (optional) - Automatically resolve merge request diffs discussions on lines changed with a push
+     * initialize_with_readme (optional) - Initialize project with README file
      *
      * @param project the Project instance with the configuration for the new project
      * @param importUrl the URL to import the repository from
@@ -698,7 +699,8 @@ public class ProjectApi extends AbstractApi implements Constants {
             .withParam("approvals_before_merge", project.getApprovalsBeforeMerge())
             .withParam("import_url", importUrl)
             .withParam("printing_merge_request_link_enabled", project.getPrintingMergeRequestLinkEnabled())
-            .withParam("resolve_outdated_diff_discussions", project.getResolveOutdatedDiffDiscussions());
+            .withParam("resolve_outdated_diff_discussions", project.getResolveOutdatedDiffDiscussions())
+            .withParam("initialize_with_readme", project.getInitializeWithReadme());
 
         if (isApiVersion(ApiVersion.V3)) {
             boolean isPublic = (project.getPublic() != null ? project.getPublic() : project.getVisibility() == Visibility.PUBLIC);
@@ -898,6 +900,7 @@ public class ProjectApi extends AbstractApi implements Constants {
      *     tag_list array
      *     avatar
      *     ci_config_path
+     *     initialize_with_readme
      *
      * @param project the Project instance with the configuration for the new project
      * @return a Project instance with the newly updated project info

--- a/src/main/java/org/gitlab4j/api/models/Project.java
+++ b/src/main/java/org/gitlab4j/api/models/Project.java
@@ -87,6 +87,7 @@ public class Project {
     private Boolean printingMergeRequestLinkEnabled;
     private Boolean resolveOutdatedDiffDiscussions;
     private ProjectStatistics statistics;
+    private Boolean initializeWithReadme;
 
     public Integer getApprovalsBeforeMerge() {
         return approvalsBeforeMerge;
@@ -604,6 +605,19 @@ public class Project {
 
     public Project withResolveOutdatedDiffDiscussions(boolean resolveOutdatedDiffDiscussions) {
         this.resolveOutdatedDiffDiscussions = resolveOutdatedDiffDiscussions;
+        return (this);
+    }
+
+    public Boolean getInitializeWithReadme() {
+        return initializeWithReadme;
+    }
+
+    public void setInitializeWithReadme(Boolean initializeWithReadme) {
+        this.initializeWithReadme = initializeWithReadme;
+    }
+
+    public Project withInitializeWithReadme(boolean initializeWithReadme) {
+        this.initializeWithReadme = initializeWithReadme;
         return (this);
     }
 

--- a/src/main/java/org/gitlab4j/api/models/Project.java
+++ b/src/main/java/org/gitlab4j/api/models/Project.java
@@ -85,6 +85,7 @@ public class Project {
     private String webUrl;
     private Boolean wikiEnabled;
     private Boolean printingMergeRequestLinkEnabled;
+    private Boolean resolveOutdatedDiffDiscussions;
     private ProjectStatistics statistics;
 
     public Integer getApprovalsBeforeMerge() {
@@ -590,6 +591,19 @@ public class Project {
 
     public Project withPrintingMergeRequestLinkEnabled(Boolean printingMergeRequestLinkEnabled) {
         this.printingMergeRequestLinkEnabled = printingMergeRequestLinkEnabled;
+        return (this);
+    }
+
+    public Boolean getResolveOutdatedDiffDiscussions() {
+        return resolveOutdatedDiffDiscussions;
+    }
+
+    public void setResolveOutdatedDiffDiscussions(Boolean resolveOutdatedDiffDiscussions) {
+        this.resolveOutdatedDiffDiscussions = resolveOutdatedDiffDiscussions;
+    }
+
+    public Project withResolveOutdatedDiffDiscussions(boolean resolveOutdatedDiffDiscussions) {
+        this.resolveOutdatedDiffDiscussions = resolveOutdatedDiffDiscussions;
         return (this);
     }
 


### PR DESCRIPTION
The [Projects API](https://docs.gitlab.com/ee/api/projects.html) supports `resolve_outdated_diff_discussions`, which is missing in the current implementation.

So adding support for `resolve_outdated_diff_discussions` to `Project`, `ProjectApi.createProject` and `ProjectApi.updateProject` allows API user to adjust the value.

Also adding support for `initialize_with_readme` to to `Project` and `ProjectApi.createProject` 